### PR TITLE
Allow initial data on Entlet creation

### DIFF
--- a/resolver/_core/entlet.py
+++ b/resolver/_core/entlet.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from hashlib import md5
 import itertools
 import json
-from typing import Any, Callable, Dict, Generator, List, Tuple, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
 from resolver._utils.functions import merge_union
 
@@ -27,13 +27,16 @@ class Entlet(object):
     CUSTOM_UID_FIELDS = None
     SOURCE_UID_FIELD = None
 
-    def __init__(self):
+    def __init__(self, initial: Optional[Dict[str, Any]] = None):
         self.values = defaultdict(list)
 
         self.fields = set()
         self.const_values = {}
 
         self._uid = None
+
+        if initial is not None:
+            self.add(initial)
 
     @property
     def required_fields(self) -> List[str]:


### PR DESCRIPTION
Allows a user to pass in a dictionary of initial values during the instantiation of the Entlet.